### PR TITLE
feat: filesystem manifest, static file routes, and file-nav island

### DIFF
--- a/src/lib/filesystem.ts
+++ b/src/lib/filesystem.ts
@@ -1,0 +1,18 @@
+import { getCollection } from 'astro:content';
+import { assembleManifest, type FilesystemManifest } from './manifest';
+
+export type { FsNode, FilesystemManifest } from './manifest';
+export { fileNodes } from './manifest';
+
+/**
+ * Walk the content collections and build the site's virtual filesystem manifest
+ * (issue #21). Thin astro:content adapter over the pure `assembleManifest` logic.
+ */
+export async function buildManifest(): Promise<FilesystemManifest> {
+  const [pages, projects, code] = await Promise.all([
+    getCollection('pages'),
+    getCollection('projects'),
+    getCollection('code'),
+  ]);
+  return assembleManifest(pages, projects, code);
+}

--- a/src/lib/manifest.test.ts
+++ b/src/lib/manifest.test.ts
@@ -1,0 +1,63 @@
+import { expect, test } from 'vitest';
+import {
+  assembleManifest,
+  fileNodes,
+  sortProjects,
+  type CodeInput,
+  type PageInput,
+  type ProjectInput,
+} from './manifest';
+
+const pages: PageInput[] = [
+  { id: 'contact', data: { title: 'contact', order: 3 } },
+  { id: 'bio', data: { title: 'bio', order: 1 } },
+  { id: 'cv', data: { title: 'cv', order: 2 } },
+];
+
+const projects: ProjectInput[] = [
+  { id: 'ongoing-foundsounds', data: { title: 'Ongoing - FoundSounds' } },
+  { id: '2016-telephone-booth', data: { title: 'Telephone Booth', year: 2016 } },
+  { id: '2004-of-dinger', data: { title: 'of Dinger', year: 2004 } },
+];
+
+const code: CodeInput[] = [{ id: 'repos', data: { title: 'repos' } }];
+
+const now = new Date('2024-01-01T00:00:00.000Z');
+
+test('pages are ordered by their order field', () => {
+  const { nodes } = assembleManifest(pages, projects, code, now);
+  const pagePaths = nodes.filter((n) => n.collection === 'pages').map((n) => n.path);
+  expect(pagePaths).toEqual(['/bio', '/cv', '/contact']);
+});
+
+test('projects sort by year, undefined year last, then id', () => {
+  const sorted = sortProjects(projects).map((p) => p.id);
+  expect(sorted).toEqual(['2004-of-dinger', '2016-telephone-booth', 'ongoing-foundsounds']);
+});
+
+test('directories are inserted before their collection files', () => {
+  const { nodes } = assembleManifest(pages, projects, code, now);
+  const projectsDirIdx = nodes.findIndex((n) => n.path === '/projects');
+  const firstProjectIdx = nodes.findIndex((n) => n.collection === 'projects');
+  expect(projectsDirIdx).toBeGreaterThanOrEqual(0);
+  expect(projectsDirIdx).toBeLessThan(firstProjectIdx);
+});
+
+test('file paths are namespaced by collection', () => {
+  const { nodes } = assembleManifest(pages, projects, code, now);
+  expect(nodes.find((n) => n.entryId === '2004-of-dinger')?.path).toBe('/projects/2004-of-dinger');
+  expect(nodes.find((n) => n.entryId === 'repos')?.path).toBe('/code/repos');
+  expect(nodes.find((n) => n.entryId === 'bio')?.path).toBe('/bio');
+});
+
+test('fileNodes excludes directories', () => {
+  const manifest = assembleManifest(pages, projects, code, now);
+  const files = fileNodes(manifest);
+  expect(files.every((n) => n.kind === 'file')).toBe(true);
+  expect(files).toHaveLength(pages.length + projects.length + code.length);
+});
+
+test('generatedAt reflects the provided clock', () => {
+  const { generatedAt } = assembleManifest(pages, projects, code, now);
+  expect(generatedAt).toBe('2024-01-01T00:00:00.000Z');
+});

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -1,0 +1,124 @@
+// A single node in the site's virtual filesystem. Directories group files;
+// files map to a rendered content entry.
+export type FsNode = {
+  /** Absolute virtual path, e.g. "/projects/2016-telephone-booth". */
+  path: string;
+  /** Display name (the last path segment for files, dir name for directories). */
+  name: string;
+  kind: 'dir' | 'file';
+  /** Human-friendly title (files only). */
+  title?: string;
+  /** Owning collection (files only). */
+  collection?: 'pages' | 'projects' | 'code';
+  /** Content entry id within its collection (files only). */
+  entryId?: string;
+  /** Year, for projects. */
+  year?: number;
+  /** Short summary/description, when available. */
+  summary?: string;
+  /** Media assets attached to the entry (projects only). */
+  media?: { type: 'image' | 'audio'; src: string; alt?: string; caption?: string }[];
+};
+
+export type FilesystemManifest = {
+  generatedAt: string;
+  nodes: FsNode[];
+};
+
+// Minimal shapes so the ordering/assembly logic can be unit-tested without the
+// astro:content runtime.
+export type PageInput = {
+  id: string;
+  data: { title: string; order: number; description?: string };
+};
+export type ProjectInput = {
+  id: string;
+  data: {
+    title: string;
+    year?: number;
+    summary?: string;
+    media?: FsNode['media'];
+  };
+};
+export type CodeInput = { id: string; data: { title: string } };
+
+export function sortPages<T extends PageInput>(pages: T[]): T[] {
+  return [...pages].sort((a, b) => a.data.order - b.data.order);
+}
+
+export function sortProjects<T extends ProjectInput>(projects: T[]): T[] {
+  return [...projects].sort((a, b) => {
+    const ay = a.data.year ?? Number.POSITIVE_INFINITY;
+    const by = b.data.year ?? Number.POSITIVE_INFINITY;
+    if (ay !== by) return ay - by;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function sortCode<T extends CodeInput>(code: T[]): T[] {
+  return [...code].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function pageNode(entry: PageInput): FsNode {
+  return {
+    path: `/${entry.id}`,
+    name: entry.id,
+    kind: 'file',
+    title: entry.data.title,
+    collection: 'pages',
+    entryId: entry.id,
+    summary: entry.data.description,
+  };
+}
+
+function projectNode(entry: ProjectInput): FsNode {
+  return {
+    path: `/projects/${entry.id}`,
+    name: entry.id,
+    kind: 'file',
+    title: entry.data.title,
+    collection: 'projects',
+    entryId: entry.id,
+    year: entry.data.year,
+    summary: entry.data.summary,
+    media: entry.data.media,
+  };
+}
+
+function codeNode(entry: CodeInput): FsNode {
+  return {
+    path: `/code/${entry.id}`,
+    name: entry.id,
+    kind: 'file',
+    title: entry.data.title,
+    collection: 'code',
+    entryId: entry.id,
+  };
+}
+
+/**
+ * Assemble the virtual filesystem manifest from already-fetched collection entries.
+ * Pages are top-level "files"; projects and code live under their own directories.
+ * Entries are sorted deterministically so navigation and generated HTML are stable.
+ * Pure and runtime-agnostic so it can be unit-tested without astro:content.
+ */
+export function assembleManifest(
+  pages: PageInput[],
+  projects: ProjectInput[],
+  code: CodeInput[],
+  now: Date = new Date(),
+): FilesystemManifest {
+  const nodes: FsNode[] = [
+    ...sortPages(pages).map(pageNode),
+    { path: '/projects', name: 'projects', kind: 'dir' },
+    ...sortProjects(projects).map(projectNode),
+    { path: '/code', name: 'code', kind: 'dir' },
+    ...sortCode(code).map(codeNode),
+  ];
+  return { generatedAt: now.toISOString(), nodes };
+}
+
+/** Files only, in manifest order — handy for building routes and listings. */
+export function fileNodes(manifest: FilesystemManifest): FsNode[] {
+  return manifest.nodes.filter((n) => n.kind === 'file');
+}

--- a/src/pages/files/[...path].astro
+++ b/src/pages/files/[...path].astro
@@ -10,28 +10,28 @@ import { buildManifest, fileNodes, type FsNode } from '../../lib/filesystem';
 
 export async function getStaticPaths() {
   const manifest = await buildManifest();
-  return fileNodes(manifest).map((node) => ({
+  const siblings = fileNodes(manifest);
+  return siblings.map((node) => ({
     // node.path is absolute ("/bio", "/projects/x"); strip the leading slash.
     params: { path: node.path.replace(/^\//, '') },
-    props: { node },
+    // Pass the sibling list through props so each route reuses one manifest walk
+    // instead of rebuilding it per page during static generation.
+    props: { node, siblings },
   }));
 }
 
 interface Props {
   node: FsNode;
+  siblings: FsNode[];
 }
 
-const { node } = Astro.props;
+const { node, siblings } = Astro.props;
 
 const entry = await getEntry(node.collection!, node.entryId!);
 if (!entry) {
   throw new Error(`No content entry for ${node.collection}/${node.entryId}`);
 }
 const { Content } = await render(entry);
-
-// Sibling links for a minimal, no-JS directory listing.
-const manifest = await buildManifest();
-const siblings = fileNodes(manifest);
 
 const repos =
   node.collection === 'code' && 'repos' in entry.data

--- a/src/pages/files/[...path].astro
+++ b/src/pages/files/[...path].astro
@@ -1,0 +1,184 @@
+---
+// Static fallback routes (issue #23).
+// One pre-rendered HTML page per content file, derived from the build-time
+// manifest (issue #21). These give every file a crawlable, no-JS, accessible URL
+// that the file-navigation island (issue #22) can deep-link to and that search
+// engines can index. Paths mirror the virtual filesystem: /files/bio,
+// /files/projects/<id>, /files/code/<id>.
+import { getEntry, render } from 'astro:content';
+import { buildManifest, fileNodes, type FsNode } from '../../lib/filesystem';
+
+export async function getStaticPaths() {
+  const manifest = await buildManifest();
+  return fileNodes(manifest).map((node) => ({
+    // node.path is absolute ("/bio", "/projects/x"); strip the leading slash.
+    params: { path: node.path.replace(/^\//, '') },
+    props: { node },
+  }));
+}
+
+interface Props {
+  node: FsNode;
+}
+
+const { node } = Astro.props;
+
+const entry = await getEntry(node.collection!, node.entryId!);
+if (!entry) {
+  throw new Error(`No content entry for ${node.collection}/${node.entryId}`);
+}
+const { Content } = await render(entry);
+
+// Sibling links for a minimal, no-JS directory listing.
+const manifest = await buildManifest();
+const siblings = fileNodes(manifest);
+
+const repos =
+  node.collection === 'code' && 'repos' in entry.data
+    ? (entry.data.repos as { name: string; url: string }[])
+    : [];
+
+const fileHref = (path: string) =>
+  `${import.meta.env.BASE_URL}files/${path.replace(/^\//, '')}`.replace(/\/{2,}/g, '/');
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{node.title} — David Jensenius</title>
+    {node.summary && <meta name="description" content={node.summary} />}
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        background: #0b0b0b;
+        color: #d7d7d7;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        display: grid;
+        grid-template-columns: 18rem 1fr;
+        min-height: 100vh;
+      }
+      nav {
+        border-right: 1px solid #222;
+        padding: 1rem;
+        overflow-y: auto;
+      }
+      nav h2 {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: #6a6a6a;
+      }
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      li {
+        padding: 0.15rem 0;
+      }
+      nav a {
+        color: #b9f27a;
+        text-decoration: none;
+        padding-left: 1rem;
+        display: inline-block;
+      }
+      nav a:hover,
+      nav a:focus-visible {
+        text-decoration: underline;
+      }
+      nav a[aria-current='page'] {
+        color: #fff;
+        font-weight: 700;
+      }
+      main {
+        padding: 2rem;
+        max-width: 70ch;
+      }
+      main a {
+        color: #7aa2f7;
+      }
+      .media {
+        margin-top: 2rem;
+        display: grid;
+        gap: 1.5rem;
+      }
+      .media figure {
+        margin: 0;
+      }
+      .media img {
+        max-width: 100%;
+        height: auto;
+        border: 1px solid #222;
+      }
+      .media audio {
+        width: 100%;
+      }
+      .media figcaption {
+        color: #6a6a6a;
+        font-size: 0.85rem;
+        margin-top: 0.35rem;
+      }
+      .prompt {
+        color: #6a6a6a;
+      }
+    </style>
+  </head>
+  <body>
+    <nav aria-label="Files">
+      <h2>~ / david</h2>
+      <ul>
+        {
+          siblings.map((s) => (
+            <li>
+              <a href={fileHref(s.path)} aria-current={s.path === node.path ? 'page' : undefined}>
+                {s.name}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+    <main>
+      <article>
+        <h1>{node.title}</h1>
+        {node.year && <p class="prompt">{node.year}</p>}
+        {
+          repos.length > 0 && (
+            <ul>
+              {repos.map((repo) => (
+                <li>
+                  <a href={repo.url}>{repo.name}</a>
+                </li>
+              ))}
+            </ul>
+          )
+        }
+        <Content />
+        {
+          node.media && node.media.length > 0 && (
+            <section class="media" aria-label="Media">
+              {node.media.map((m) =>
+                m.type === 'image' ? (
+                  <figure>
+                    <img src={m.src} alt={m.alt ?? ''} loading="lazy" />
+                    {m.caption && <figcaption>{m.caption}</figcaption>}
+                  </figure>
+                ) : (
+                  <figure>
+                    <audio controls src={m.src} preload="none" />
+                    {m.caption && <figcaption>{m.caption}</figcaption>}
+                  </figure>
+                ),
+              )}
+            </section>
+          )
+        }
+      </article>
+    </main>
+  </body>
+</html>

--- a/src/pages/files/index.astro
+++ b/src/pages/files/index.astro
@@ -1,0 +1,247 @@
+---
+// File-navigation island (issue #22).
+// The interactive, artistic file browser that graduates the Phase 1 spike
+// (src/pages/spike/files.astro). It fetches the build-time manifest (issue #21),
+// renders an ls-style directory tree, and loads file content on demand from the
+// static fallback routes (issue #23) so it degrades gracefully and shares one
+// source of rendered HTML. Deep-links via the URL hash (e.g. #/projects/<id>).
+// Vanilla TS by design — the spike showed no framework is warranted here.
+const base = import.meta.env.BASE_URL;
+const bioHref = `${base}files/bio`.replace(/\/{2,}/g, '/');
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Files — David Jensenius</title>
+    <meta name="description" content="Browse the work of David Jensenius." />
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        background: #0b0b0b;
+        color: #d7d7d7;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        display: grid;
+        grid-template-columns: 20rem 1fr;
+        min-height: 100vh;
+      }
+      nav {
+        border-right: 1px solid #222;
+        padding: 1rem;
+        overflow-y: auto;
+      }
+      nav h2 {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: #6a6a6a;
+      }
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      li {
+        padding: 0.1rem 0;
+      }
+      li.dir {
+        color: #7aa2f7;
+        margin-top: 0.5rem;
+      }
+      li.file {
+        padding-left: 1rem;
+      }
+      a.entry {
+        all: unset;
+        cursor: pointer;
+        color: #b9f27a;
+      }
+      a.entry:hover,
+      a.entry:focus-visible {
+        text-decoration: underline;
+        outline: none;
+      }
+      a.entry[aria-current='page'] {
+        color: #fff;
+        font-weight: 700;
+      }
+      main {
+        padding: 2rem;
+        max-width: 72ch;
+      }
+      main a {
+        color: #7aa2f7;
+      }
+      .prompt {
+        color: #6a6a6a;
+      }
+      .media {
+        margin-top: 2rem;
+        display: grid;
+        gap: 1.5rem;
+      }
+      .media img {
+        max-width: 100%;
+        height: auto;
+        border: 1px solid #222;
+      }
+      .media audio {
+        width: 100%;
+      }
+      [hidden] {
+        display: none !important;
+      }
+    </style>
+  </head>
+  <body data-base={base}>
+    <nav aria-label="Files">
+      <h2>~ / david</h2>
+      <ul id="tree">
+        <li class="prompt">Loading…</li>
+      </ul>
+    </nav>
+    <main id="viewer" aria-live="polite" tabindex="-1">
+      <p class="prompt" id="empty">Select a file to <code>cat</code> it.</p>
+      <noscript>
+        <p>
+          JavaScript is off. Browse the files directly starting at
+          <a href={bioHref}>bio</a>.
+        </p>
+      </noscript>
+    </main>
+
+    <script>
+      type FsNode = {
+        path: string;
+        name: string;
+        kind: 'dir' | 'file';
+        title?: string;
+        year?: number;
+      };
+      type Manifest = { generatedAt: string; nodes: FsNode[] };
+
+      const base = document.body.dataset.base ?? '/';
+      const join = (...parts: string[]) => (base + parts.join('/')).replace(/\/{2,}/g, '/');
+
+      const tree = document.getElementById('tree') as HTMLUListElement;
+      const viewer = document.getElementById('viewer') as HTMLElement;
+      const empty = document.getElementById('empty') as HTMLElement;
+
+      let files: FsNode[] = [];
+
+      function render(nodes: FsNode[]) {
+        tree.replaceChildren();
+        for (const node of nodes) {
+          const li = document.createElement('li');
+          if (node.kind === 'dir') {
+            li.className = 'dir';
+            li.textContent = `${node.name}/`;
+          } else {
+            li.className = 'file';
+            const a = document.createElement('a');
+            a.className = 'entry';
+            a.href = `#${node.path}`;
+            a.dataset.path = node.path;
+            a.textContent = node.name;
+            li.append(a);
+          }
+          tree.append(li);
+        }
+      }
+
+      function markCurrent(path: string | null) {
+        for (const a of tree.querySelectorAll<HTMLAnchorElement>('a.entry')) {
+          if (a.dataset.path === path) a.setAttribute('aria-current', 'page');
+          else a.removeAttribute('aria-current');
+        }
+      }
+
+      async function open(path: string) {
+        const node = files.find((f) => f.path === path);
+        if (!node) return;
+        empty.hidden = true;
+        markCurrent(path);
+        viewer.querySelector('article')?.remove();
+        const loading = document.createElement('p');
+        loading.className = 'prompt';
+        loading.textContent = `cat ${path}…`;
+        viewer.append(loading);
+        try {
+          const res = await fetch(join('files', path.replace(/^\//, '')));
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const html = await res.text();
+          const doc = new DOMParser().parseFromString(html, 'text/html');
+          const article = doc.querySelector('article');
+          loading.remove();
+          if (article) {
+            viewer.append(article);
+            viewer.focus();
+          }
+        } catch (err) {
+          loading.remove();
+          const p = document.createElement('p');
+          p.className = 'prompt';
+          p.textContent = `Could not load ${path}: ${(err as Error).message}`;
+          viewer.append(p);
+        }
+      }
+
+      function currentIndex(): number {
+        const active = tree.querySelector<HTMLAnchorElement>('a.entry[aria-current="page"]');
+        const entries = [...tree.querySelectorAll<HTMLAnchorElement>('a.entry')];
+        return active ? entries.indexOf(active) : -1;
+      }
+
+      function move(delta: number) {
+        const entries = [...tree.querySelectorAll<HTMLAnchorElement>('a.entry')];
+        if (entries.length === 0) return;
+        const next = Math.max(0, Math.min(entries.length - 1, currentIndex() + delta));
+        const target = entries[next];
+        target.focus();
+        location.hash = target.dataset.path ?? '';
+      }
+
+      function fromHash() {
+        const path = location.hash.replace(/^#/, '');
+        if (path) void open(path);
+        else {
+          markCurrent(null);
+          empty.hidden = false;
+        }
+      }
+
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          move(1);
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          move(-1);
+        }
+      });
+
+      window.addEventListener('hashchange', fromHash);
+
+      (async () => {
+        try {
+          const res = await fetch(join('manifest.json'));
+          const manifest: Manifest = await res.json();
+          files = manifest.nodes.filter((n) => n.kind === 'file');
+          render(manifest.nodes);
+          fromHash();
+        } catch (err) {
+          tree.replaceChildren();
+          const li = document.createElement('li');
+          li.className = 'prompt';
+          li.textContent = `Failed to load manifest: ${(err as Error).message}`;
+          tree.append(li);
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/src/pages/files/index.astro
+++ b/src/pages/files/index.astro
@@ -166,9 +166,12 @@ const bioHref = `${base}files/bio`.replace(/\/{2,}/g, '/');
         if (!node) return;
         empty.hidden = true;
         markCurrent(path);
+        // Clear the previous article and any lingering status/error prompts so
+        // messages don't accumulate across successive opens.
         viewer.querySelector('article')?.remove();
+        viewer.querySelectorAll('p.status').forEach((el) => el.remove());
         const loading = document.createElement('p');
-        loading.className = 'prompt';
+        loading.className = 'prompt status';
         loading.textContent = `cat ${path}…`;
         viewer.append(loading);
         try {
@@ -177,15 +180,14 @@ const bioHref = `${base}files/bio`.replace(/\/{2,}/g, '/');
           const html = await res.text();
           const doc = new DOMParser().parseFromString(html, 'text/html');
           const article = doc.querySelector('article');
+          if (!article) throw new Error('no content found');
           loading.remove();
-          if (article) {
-            viewer.append(article);
-            viewer.focus();
-          }
+          viewer.append(article);
+          viewer.focus();
         } catch (err) {
           loading.remove();
           const p = document.createElement('p');
-          p.className = 'prompt';
+          p.className = 'prompt status';
           p.textContent = `Could not load ${path}: ${(err as Error).message}`;
           viewer.append(p);
         }

--- a/src/pages/manifest.json.ts
+++ b/src/pages/manifest.json.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from 'astro';
+import { buildManifest } from '../lib/filesystem';
+
+// Build-time JSON filesystem manifest (issue #21). Emitted as a static file so the
+// client-side file-navigation island and any external consumers can fetch the
+// virtual filesystem without re-walking the content collections.
+export const GET: APIRoute = async () => {
+  const manifest = await buildManifest();
+  return new Response(JSON.stringify(manifest, null, 2), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};


### PR DESCRIPTION
## Phase 3 — modern web layer (part 1)

Builds the modern Markdown-driven file-navigation experience on top of the migrated content. Emulator (#37/#33/#34) and the mode toggle (#35) land in follow-up PRs.

### What is here
- **#21 Filesystem manifest**
  - `src/lib/manifest.ts` — pure, runtime-agnostic assembly with deterministic ordering (pages by `order`, projects by `year` then `id`, code by `id`) + `fileNodes` helper. Unit-tested (`src/lib/manifest.test.ts`) without needing the `astro:content` runtime.
  - `src/lib/filesystem.ts` — thin `astro:content` adapter (`buildManifest`).
  - `src/pages/manifest.json.ts` — static `/manifest.json` endpoint.
- **#23 Static fallback routes**
  - `src/pages/files/[...path].astro` — one pre-rendered, no-JS, crawlable HTML page per content file (SEO/a11y). Mirrors the virtual filesystem (`/files/bio`, `/files/projects/<id>`, `/files/code/<id>`), renders optional image/audio media.
- **#22 File-navigation island**
  - `src/pages/files/index.astro` — interactive browser: fetches the manifest, ls-style directory tree, keyboard nav, URL-hash deep-linking, loads file content on demand from the static routes (progressive enhancement, degrades to the no-JS pages). Graduates the Phase 1 spike; vanilla TS as the spike recommended.

### Validation
- `just check` -> 0 errors / 0 warnings
- `just test` -> 7 passing
- `just build` -> 34 pages incl. `/manifest.json` (33 nodes) and all `/files/*`
- Served build: `/`, `/files/`, `/files/bio`, `/files/projects/2016-telephone-booth`, `/manifest.json` all 200; island injects the rendered article correctly.

Part of epic #14.
