### PR TITLE
feat: auto light/dark theme and directories-first, newest-first file ordering

### DIFF
--- a/src/lib/manifest.test.ts
+++ b/src/lib/manifest.test.ts
@@ -30,17 +30,20 @@ test('pages are ordered by their order field', () => {
   expect(pagePaths).toEqual(['/bio', '/cv', '/contact']);
 });
 
-test('projects sort by year, undefined year last, then id', () => {
+test('projects sort newest-first: no-year first, then year desc, then id desc', () => {
   const sorted = sortProjects(projects).map((p) => p.id);
-  expect(sorted).toEqual(['2004-of-dinger', '2016-telephone-booth', 'ongoing-foundsounds']);
+  expect(sorted).toEqual(['ongoing-foundsounds', '2016-telephone-booth', '2004-of-dinger']);
 });
 
-test('directories are inserted before their collection files', () => {
+test('directories are listed before their files and before top-level pages', () => {
   const { nodes } = assembleManifest(pages, projects, code, now);
   const projectsDirIdx = nodes.findIndex((n) => n.path === '/projects');
   const firstProjectIdx = nodes.findIndex((n) => n.collection === 'projects');
-  expect(projectsDirIdx).toBeGreaterThanOrEqual(0);
+  const firstPageIdx = nodes.findIndex((n) => n.collection === 'pages');
+  expect(projectsDirIdx).toBe(0);
   expect(projectsDirIdx).toBeLessThan(firstProjectIdx);
+  // Top-level page files come after the directories and their contents.
+  expect(firstPageIdx).toBeGreaterThan(firstProjectIdx);
 });
 
 test('file paths are namespaced by collection', () => {

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -46,12 +46,15 @@ export function sortPages<T extends PageInput>(pages: T[]): T[] {
   return [...pages].sort((a, b) => a.data.order - b.data.order);
 }
 
+// Projects are listed newest-first: entries with no year (ongoing work) sort to
+// the very top, then descending by year, then descending by id as a stable
+// tiebreak so the whole list reads most-recent → oldest.
 export function sortProjects<T extends ProjectInput>(projects: T[]): T[] {
   return [...projects].sort((a, b) => {
     const ay = a.data.year ?? Number.POSITIVE_INFINITY;
     const by = b.data.year ?? Number.POSITIVE_INFINITY;
-    if (ay !== by) return ay - by;
-    return a.id.localeCompare(b.id);
+    if (ay !== by) return by - ay;
+    return b.id.localeCompare(a.id);
   });
 }
 
@@ -98,8 +101,9 @@ function codeNode(entry: CodeInput): FsNode {
 
 /**
  * Assemble the virtual filesystem manifest from already-fetched collection entries.
- * Pages are top-level "files"; projects and code live under their own directories.
- * Entries are sorted deterministically so navigation and generated HTML are stable.
+ * Directories are listed first (each followed by its files, newest-first); the
+ * top-level page "files" (bio/cv/contact) come last, in their defined order.
+ * Ordering is deterministic so navigation and generated HTML are stable.
  * Pure and runtime-agnostic so it can be unit-tested without astro:content.
  */
 export function assembleManifest(
@@ -109,11 +113,11 @@ export function assembleManifest(
   now: Date = new Date(),
 ): FilesystemManifest {
   const nodes: FsNode[] = [
-    ...sortPages(pages).map(pageNode),
     { path: '/projects', name: 'projects', kind: 'dir' },
     ...sortProjects(projects).map(projectNode),
     { path: '/code', name: 'code', kind: 'dir' },
     ...sortCode(code).map(codeNode),
+    ...sortPages(pages).map(pageNode),
   ];
   return { generatedAt: now.toISOString(), nodes };
 }

--- a/src/pages/files/[...path].astro
+++ b/src/pages/files/[...path].astro
@@ -7,25 +7,25 @@
 // /files/projects/<id>, /files/code/<id>.
 import { getEntry, render } from 'astro:content';
 import { buildManifest, fileNodes, type FsNode } from '../../lib/filesystem';
+import '../../styles/file-view.css';
 
 export async function getStaticPaths() {
   const manifest = await buildManifest();
-  const siblings = fileNodes(manifest);
-  return siblings.map((node) => ({
+  return fileNodes(manifest).map((node) => ({
     // node.path is absolute ("/bio", "/projects/x"); strip the leading slash.
     params: { path: node.path.replace(/^\//, '') },
-    // Pass the sibling list through props so each route reuses one manifest walk
-    // instead of rebuilding it per page during static generation.
-    props: { node, siblings },
+    // Pass the full node list through props so each route reuses one manifest
+    // walk instead of rebuilding it per page during static generation.
+    props: { node, tree: manifest.nodes },
   }));
 }
 
 interface Props {
   node: FsNode;
-  siblings: FsNode[];
+  tree: FsNode[];
 }
 
-const { node, siblings } = Astro.props;
+const { node, tree } = Astro.props;
 
 const entry = await getEntry(node.collection!, node.entryId!);
 if (!entry) {
@@ -49,97 +49,27 @@ const fileHref = (path: string) =>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{node.title} — David Jensenius</title>
     {node.summary && <meta name="description" content={node.summary} />}
-    <style>
-      :root {
-        color-scheme: dark;
-      }
-      body {
-        margin: 0;
-        background: #0b0b0b;
-        color: #d7d7d7;
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-        display: grid;
-        grid-template-columns: 18rem 1fr;
-        min-height: 100vh;
-      }
-      nav {
-        border-right: 1px solid #222;
-        padding: 1rem;
-        overflow-y: auto;
-      }
-      nav h2 {
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.1em;
-        color: #6a6a6a;
-      }
-      ul {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-      }
-      li {
-        padding: 0.15rem 0;
-      }
-      nav a {
-        color: #b9f27a;
-        text-decoration: none;
-        padding-left: 1rem;
-        display: inline-block;
-      }
-      nav a:hover,
-      nav a:focus-visible {
-        text-decoration: underline;
-      }
-      nav a[aria-current='page'] {
-        color: #fff;
-        font-weight: 700;
-      }
-      main {
-        padding: 2rem;
-        max-width: 70ch;
-      }
-      main a {
-        color: #7aa2f7;
-      }
-      .media {
-        margin-top: 2rem;
-        display: grid;
-        gap: 1.5rem;
-      }
-      .media figure {
-        margin: 0;
-      }
-      .media img {
-        max-width: 100%;
-        height: auto;
-        border: 1px solid #222;
-      }
-      .media audio {
-        width: 100%;
-      }
-      .media figcaption {
-        color: #6a6a6a;
-        font-size: 0.85rem;
-        margin-top: 0.35rem;
-      }
-      .prompt {
-        color: #6a6a6a;
-      }
-    </style>
   </head>
   <body>
     <nav aria-label="Files">
       <h2>~ / david</h2>
       <ul>
         {
-          siblings.map((s) => (
-            <li>
-              <a href={fileHref(s.path)} aria-current={s.path === node.path ? 'page' : undefined}>
-                {s.name}
-              </a>
-            </li>
-          ))
+          tree.map((n) =>
+            n.kind === 'dir' ? (
+              <li class="dir">{n.name}/</li>
+            ) : (
+              <li class="file">
+                <a
+                  class="entry"
+                  href={fileHref(n.path)}
+                  aria-current={n.path === node.path ? 'page' : undefined}
+                >
+                  {n.name}
+                </a>
+              </li>
+            ),
+          )
         }
       </ul>
     </nav>

--- a/src/pages/files/index.astro
+++ b/src/pages/files/index.astro
@@ -8,6 +8,7 @@
 // Vanilla TS by design — the spike showed no framework is warranted here.
 const base = import.meta.env.BASE_URL;
 const bioHref = `${base}files/bio`.replace(/\/{2,}/g, '/');
+import '../../styles/file-view.css';
 ---
 
 <!doctype html>
@@ -17,86 +18,6 @@ const bioHref = `${base}files/bio`.replace(/\/{2,}/g, '/');
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Files — David Jensenius</title>
     <meta name="description" content="Browse the work of David Jensenius." />
-    <style>
-      :root {
-        color-scheme: dark;
-      }
-      body {
-        margin: 0;
-        background: #0b0b0b;
-        color: #d7d7d7;
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-        display: grid;
-        grid-template-columns: 20rem 1fr;
-        min-height: 100vh;
-      }
-      nav {
-        border-right: 1px solid #222;
-        padding: 1rem;
-        overflow-y: auto;
-      }
-      nav h2 {
-        font-size: 0.75rem;
-        text-transform: uppercase;
-        letter-spacing: 0.1em;
-        color: #6a6a6a;
-      }
-      ul {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-      }
-      li {
-        padding: 0.1rem 0;
-      }
-      li.dir {
-        color: #7aa2f7;
-        margin-top: 0.5rem;
-      }
-      li.file {
-        padding-left: 1rem;
-      }
-      a.entry {
-        all: unset;
-        cursor: pointer;
-        color: #b9f27a;
-      }
-      a.entry:hover,
-      a.entry:focus-visible {
-        text-decoration: underline;
-        outline: none;
-      }
-      a.entry[aria-current='page'] {
-        color: #fff;
-        font-weight: 700;
-      }
-      main {
-        padding: 2rem;
-        max-width: 72ch;
-      }
-      main a {
-        color: #7aa2f7;
-      }
-      .prompt {
-        color: #6a6a6a;
-      }
-      .media {
-        margin-top: 2rem;
-        display: grid;
-        gap: 1.5rem;
-      }
-      .media img {
-        max-width: 100%;
-        height: auto;
-        border: 1px solid #222;
-      }
-      .media audio {
-        width: 100%;
-      }
-      [hidden] {
-        display: none !important;
-      }
-    </style>
   </head>
   <body data-base={base}>
     <nav aria-label="Files">

--- a/src/styles/file-view.css
+++ b/src/styles/file-view.css
@@ -1,0 +1,136 @@
+/*
+ * Shared styling for the file-navigation views (island + static routes).
+ * Terminal aesthetic with an automatic light/dark theme: dark is the default
+ * palette and the `prefers-color-scheme: light` block swaps the variables so the
+ * theme follows the OS/browser setting with no toggle or JavaScript.
+ */
+:root {
+  color-scheme: light dark;
+  --bg: #0b0b0b;
+  --fg: #d7d7d7;
+  --muted: #6a6a6a;
+  --border: #222222;
+  --dir: #7aa2f7;
+  --file: #b9f27a;
+  --accent: #ffffff;
+  --link: #7aa2f7;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #fbfbfa;
+    --fg: #1a1a1a;
+    --muted: #6a6a6a;
+    --border: #d8d8d4;
+    --dir: #1d4ed8;
+    --file: #15803d;
+    --accent: #000000;
+    --link: #1d4ed8;
+  }
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  display: grid;
+  grid-template-columns: 18rem 1fr;
+  min-height: 100vh;
+}
+
+nav {
+  border-right: 1px solid var(--border);
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+nav h2 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+li {
+  padding: 0.1rem 0;
+}
+
+li.dir {
+  color: var(--dir);
+  margin-top: 0.5rem;
+}
+
+li.file {
+  padding-left: 1rem;
+}
+
+a.entry {
+  all: unset;
+  cursor: pointer;
+  color: var(--file);
+}
+
+a.entry:hover {
+  text-decoration: underline;
+}
+
+a.entry:focus-visible {
+  outline: 2px solid var(--file);
+  outline-offset: 2px;
+  text-decoration: underline;
+}
+
+a.entry[aria-current='page'] {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+main {
+  padding: 2rem;
+  max-width: 72ch;
+}
+
+main a {
+  color: var(--link);
+}
+
+.prompt {
+  color: var(--muted);
+}
+
+.media {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.media figure {
+  margin: 0;
+}
+
+.media img {
+  max-width: 100%;
+  height: auto;
+  border: 1px solid var(--border);
+}
+
+.media audio {
+  width: 100%;
+}
+
+.media figcaption {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-top: 0.35rem;
+}
+
+[hidden] {
+  display: none !important;
+}


### PR DESCRIPTION
## File-navigation refinements

Two requested tweaks to the file-navigation views shipped in #47.

### Auto light/dark theme
- New `src/styles/file-view.css` centralizes the shared file-view styling (removing duplication between the island and the static routes) and adds an **automatic light/dark theme** via CSS custom properties + `@media (prefers-color-scheme: light)`. It follows the OS/browser setting — no toggle, no JavaScript. `color-scheme: light dark` lets form controls/scrollbars adapt too.

### Directories up top, newest files first
- Manifest ordering now lists **directories first** (`projects/`, then `code/`, each followed by its files), with the top-level page files (`bio`/`cv`/`contact`) last.
- **Projects list newest-first**: ongoing work first, then year descending, then id descending — so the most recent work is at the top.
- The static fallback nav now renders directory headers too, matching the island.

### Validation
- `just check` -> 0 errors / 0 warnings
- `just test` -> 7 passing (ordering assertions updated)
- `just build` -> 34 pages; verified manifest order (projects newest-first -> code -> pages), inlined light/dark CSS, and `projects/`+`code/` headers in the static nav.

Part of epic #14 (Phase 3).
