### PR TITLE
fix: keep mode switcher placement consistent

### DIFF
--- a/src/pages/files/[...path].astro
+++ b/src/pages/files/[...path].astro
@@ -6,6 +6,7 @@
 // engines can index. Paths mirror the virtual filesystem: /files/bio,
 // /files/projects/<id>, /files/code/<id>.
 import { getEntry, render } from 'astro:content';
+import ModeToggle from '../../components/ModeToggle.astro';
 import { buildManifest, fileNodes, type FsNode } from '../../lib/filesystem';
 import '../../styles/file-view.css';
 
@@ -51,6 +52,9 @@ const fileHref = (path: string) =>
     {node.summary && <meta name="description" content={node.summary} />}
   </head>
   <body>
+    <div class="modebar">
+      <ModeToggle active="files" />
+    </div>
     <nav aria-label="Files">
       <h2>~ / david</h2>
       <ul>

--- a/src/pages/files/index.astro
+++ b/src/pages/files/index.astro
@@ -21,10 +21,10 @@ import '../../styles/file-view.css';
     <meta name="description" content="Browse the work of David Jensenius." />
   </head>
   <body data-base={base}>
+    <div class="modebar">
+      <ModeToggle active="files" />
+    </div>
     <nav aria-label="Files">
-      <div class="modebar">
-        <ModeToggle active="files" />
-      </div>
       <h2>~ / david</h2>
       <ul id="tree">
         <li class="prompt">Loading…</li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,9 +22,11 @@ const title = 'David Jensenius';
   <body>
     <div class="shell">
       <header class="masthead">
+        <div class="modebar">
+          <ModeToggle active="terminal" />
+        </div>
         <div class="titlebar">
           <h1>{title}</h1>
-          <ModeToggle active="terminal" />
         </div>
         <p class="tagline">
           Composer and media artist. Switch to <strong>Files</strong> above for plain pages.
@@ -81,12 +83,17 @@ const title = 'David Jensenius';
         margin-bottom: 0.75rem;
       }
 
+      .modebar {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        min-height: 2.2rem;
+        margin-bottom: 0.75rem;
+      }
+
       .titlebar {
         display: flex;
         align-items: center;
-        justify-content: space-between;
-        gap: 1rem;
-        flex-wrap: wrap;
       }
 
       .masthead h1 {

--- a/src/styles/file-view.css
+++ b/src/styles/file-view.css
@@ -36,10 +36,23 @@ body {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   display: grid;
   grid-template-columns: 18rem 1fr;
+  grid-template-rows: auto 1fr;
   min-height: 100vh;
 }
 
+.modebar {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  min-height: 2.2rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
 nav {
+  grid-column: 1;
+  grid-row: 2;
   border-right: 1px solid var(--border);
   padding: 1rem;
   overflow-y: auto;
@@ -50,10 +63,6 @@ nav h2 {
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--muted);
-}
-
-.modebar {
-  margin-bottom: 1rem;
 }
 
 ul {
@@ -97,6 +106,8 @@ a.entry[aria-current='page'] {
 }
 
 main {
+  grid-column: 2;
+  grid-row: 2;
   padding: 2rem;
   max-width: 72ch;
 }


### PR DESCRIPTION
Closes #55

Summary:
- Moves the Terminal/Files mode switcher into a consistent top-right bar on the landing and file views.
- Adds the same switcher placement to static file-detail routes with files mode active.
- Reserves stable top-bar space so navigation does not shift the control.