### PR TITLE
fix: cache CI Buildroot builds, add Dependabot + scheduled LTS kernel bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Keep GitHub Actions pinned versions current (security + feature updates).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+    labels:
+      - dependencies
+      - github-actions
+
+  # Node/npm dependencies for the Astro + Vite+ site.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      # Batch low-risk dev/tooling bumps into a single PR to cut review noise.
+      dev-dependencies:
+        dependency-type: development

--- a/.github/workflows/build-v86-image.yml
+++ b/.github/workflows/build-v86-image.yml
@@ -67,11 +67,44 @@ jobs:
           restore-keys: |
             v86-dl-
 
+      # Cache the compiled Buildroot tree (cross toolchain + built packages) so a
+      # re-build doesn't recompile glibc + Rust `bat` from scratch (~45 min cold →
+      # ~5-10 min warm). This replicates what the local Docker named volume does;
+      # CI runners are native Linux ext4, so the macOS-only stamp.os/virtiofs bug
+      # that forces the named volume locally doesn't apply here — a bind-mounted
+      # host path (V86_WORK_DIR) is used instead so actions/cache can persist it.
+      # The regeneratable rootfs (target/staging/images) is trimmed before save
+      # (see below) and always rebuilt clean via CLEAN_TARGET=1, so only the
+      # expensive-to-produce toolchain + package objects are cached.
+      - name: Cache Buildroot tree
+        uses: actions/cache@v6
+        with:
+          path: build/v86-image/work
+          key: v86-work-${{ hashFiles('scripts/v86-image/**', 'scripts/build-v86-image.sh') }}
+          restore-keys: |
+            v86-work-
+
       - name: Build image
+        env:
+          # Bind-mount the work tree to a host path so the cache above persists it.
+          V86_WORK_DIR: build/v86-image/work
+          # Always rebuild the rootfs from scratch (keeps compiled packages, wipes
+          # target/staging/images) so a restored tree can never carry stale files.
+          CLEAN_TARGET: '1'
         run: just v86-image
 
       - name: Smoke test (boot + 9p mount)
         run: node scripts/v86-smoke.mjs
+
+      # Drop the regeneratable rootfs trees before actions/cache saves the work
+      # dir, so the cached artifact stays lean (toolchain + package objects only).
+      # CLEAN_TARGET=1 recreates these on the next run.
+      - name: Trim cache footprint
+        if: always()
+        run: |
+          rm -rf build/v86-image/work/*/output/target \
+                 build/v86-image/work/*/output/staging \
+                 build/v86-image/work/*/output/images || true
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/kernel-update.yml
+++ b/.github/workflows/kernel-update.yml
@@ -1,0 +1,147 @@
+name: Update emulator kernel (LTS)
+
+# Periodically track the newest upstream *longterm* (LTS) Linux kernel and, if it
+# differs from the version pinned in scripts/v86-image/config.fragment, rebuild
+# the v86 image on it and run the full boot + 9p smoke test. A pull request is
+# opened ONLY when the new kernel actually boots under v86 — the smoke test is the
+# gate, because newer kernels have historically hung under v86 (which is exactly
+# why the version is pinned). A human vets and merges the PR.
+
+on:
+  schedule:
+    - cron: '0 6 1 * *' # 06:00 UTC on the 1st of each month
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Force a specific kernel version (e.g. 6.6.99). Blank = latest LTS.'
+        required: false
+        default: ''
+
+concurrency:
+  group: kernel-update
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    name: Try latest LTS kernel
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the bump branch
+      pull-requests: write # open the PR
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve target kernel version
+        id: ver
+        run: |
+          set -euo pipefail
+          config=scripts/v86-image/config.fragment
+          current=$(grep -oP 'BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE="\K[^"]+' "$config")
+          forced='${{ github.event.inputs.version }}'
+          if [ -n "$forced" ]; then
+            target="$forced"
+          else
+            # Highest version among kernel.org "longterm" (LTS) releases.
+            target=$(curl -fsSL https://www.kernel.org/releases.json \
+              | jq -r '.releases[] | select(.moniker=="longterm") | .version' \
+              | sort -V | tail -1)
+          fi
+          echo "current=$current" >>"$GITHUB_OUTPUT"
+          echo "target=$target"   >>"$GITHUB_OUTPUT"
+          if [ "$current" = "$target" ]; then
+            echo "changed=false" >>"$GITHUB_OUTPUT"
+            echo "Already on the latest LTS kernel ($current); nothing to do."
+          else
+            echo "changed=true" >>"$GITHUB_OUTPUT"
+            echo "New LTS kernel available: $current -> $target"
+          fi
+
+      - name: Apply kernel bump
+        if: steps.ver.outputs.changed == 'true'
+        run: |
+          set -euo pipefail
+          sed -i 's/BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE="[^"]*"/BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE="${{ steps.ver.outputs.target }}"/' \
+            scripts/v86-image/config.fragment
+          grep BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE scripts/v86-image/config.fragment
+
+      # Reclaim space, then build the image on the new kernel using the same
+      # caches as build-v86-image.yml so this stays fast when warm.
+      - name: Free up disk space
+        if: steps.ver.outputs.changed == 'true'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force || true
+          df -h /
+
+      - name: Set up tools (mise → Node, just)
+        if: steps.ver.outputs.changed == 'true'
+        uses: jdx/mise-action@v4
+
+      - name: Cache Buildroot downloads
+        if: steps.ver.outputs.changed == 'true'
+        uses: actions/cache@v6
+        with:
+          path: build/v86-image/dl
+          key: v86-dl-${{ hashFiles('scripts/v86-image/config.fragment', 'scripts/v86-image/base.config', 'scripts/build-v86-image.sh') }}
+          restore-keys: |
+            v86-dl-
+
+      - name: Cache Buildroot tree
+        if: steps.ver.outputs.changed == 'true'
+        uses: actions/cache@v6
+        with:
+          path: build/v86-image/work
+          key: v86-work-${{ hashFiles('scripts/v86-image/**', 'scripts/build-v86-image.sh') }}
+          restore-keys: |
+            v86-work-
+
+      - name: Build image on new kernel
+        if: steps.ver.outputs.changed == 'true'
+        env:
+          V86_WORK_DIR: build/v86-image/work
+          CLEAN_TARGET: '1'
+        run: just v86-image
+
+      - name: Smoke test (boot + 9p mount) — the gate
+        if: steps.ver.outputs.changed == 'true'
+        run: node scripts/v86-smoke.mjs
+
+      - name: Trim cache footprint
+        if: always()
+        run: |
+          rm -rf build/v86-image/work/*/output/target \
+                 build/v86-image/work/*/output/staging \
+                 build/v86-image/work/*/output/images || true
+
+      # Only reached if the smoke test above passed.
+      - name: Open pull request
+        if: steps.ver.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          target='${{ steps.ver.outputs.target }}'
+          current='${{ steps.ver.outputs.current }}'
+          branch="automation/kernel-bump-${target}"
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$branch"
+          git add scripts/v86-image/config.fragment
+          git commit -m "fix: bump emulator kernel to LTS ${target}"
+          git push --force-with-lease -u origin "$branch"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if gh pr view "$branch" >/dev/null 2>&1; then
+            echo "PR already open for $branch."
+          else
+            body=$(printf '%s\n' \
+              "Automated LTS kernel bump: \`${current}\` -> \`${target}\`." \
+              "" \
+              "This PR was opened **only because the new kernel booted under v86** — the full boot + 9p smoke test passed in [this run](${run_url})." \
+              "" \
+              "Note: because it was opened by the automation token, the \`build-v86-image\` workflow won't auto-run here. The image was already built + smoke-tested green in the linked run; close/reopen the PR (or push an empty commit) to trigger CI before merging.")
+            gh pr create --base main --head "$branch" \
+              --title "fix: bump emulator kernel to LTS ${target}" \
+              --body "$body"
+          fi

--- a/scripts/build-v86-image.sh
+++ b/scripts/build-v86-image.sh
@@ -54,9 +54,13 @@ docker build \
 
 echo "==> Running Buildroot build (tree in ${work_mount_src}, dl cache in ${dl_dir})"
 # Docker initialises named volumes as root:root; hand it to the unprivileged
-# builder uid/gid so the in-container build (which must not run as root) can write.
-docker run --rm -u 0:0 --entrypoint chown -v "${work_mount_src}:/work" "$image_tag" \
-  -R "$(id -u):$(id -g)" /work
+# builder uid/gid so the in-container build (which must not run as root) can
+# write. A bind-mounted host dir (V86_WORK_DIR, i.e. CI) is already owned by the
+# invoking user, so skip the (slow, recursive) chown fixup in that case.
+if [[ -z "${V86_WORK_DIR:-}" ]]; then
+  docker run --rm -u 0:0 --entrypoint chown -v "${work_mount_src}:/work" "$image_tag" \
+    -R "$(id -u):$(id -g)" /work
+fi
 docker run --rm \
   -e "CLEAN_TARGET=${CLEAN_TARGET:-0}" \
   -e "BR_VERSION=${BR_VERSION:-}" \

--- a/scripts/build-v86-image.sh
+++ b/scripts/build-v86-image.sh
@@ -37,6 +37,15 @@ mkdir -p "$work_dir" "$dl_dir" "$out_dir"
 #     Linux ext4, so the mtime bug doesn't apply, and a host path lets
 #     actions/cache persist the compiled toolchain + packages across runs.
 if [[ -n "${V86_WORK_DIR:-}" ]]; then
+  # Bind-mount mode is CI-only. On macOS the glibc stamp.os dependency tracking
+  # breaks on OrbStack/virtiofs mtime semantics, so hard-error rather than let a
+  # local user hit the confusing "No rule to make target .../stamp.os" failure.
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "error: V86_WORK_DIR (bind-mount mode) is unsupported on macOS — glibc's" >&2
+    echo "       stamp.os tracking breaks on OrbStack/virtiofs. Unset V86_WORK_DIR" >&2
+    echo "       to use the default named volume; bind-mount mode is CI-only." >&2
+    exit 1
+  fi
   mkdir -p "$V86_WORK_DIR"
   work_mount_src="$(cd "$V86_WORK_DIR" && pwd)"
   echo "==> Using bind-mounted work tree: ${work_mount_src}"

--- a/scripts/build-v86-image.sh
+++ b/scripts/build-v86-image.sh
@@ -29,7 +29,21 @@ image_tag="djensenius-v86-image-builder"
 work_volume="djensenius-v86-buildroot-work"
 
 mkdir -p "$work_dir" "$dl_dir" "$out_dir"
-docker volume create "$work_volume" >/dev/null
+
+# Where the Buildroot tree lives (mounted at /work in the container):
+#   - Locally (default): a Docker named volume — required to avoid the glibc
+#     stamp.os/virtiofs mtime bug on macOS/OrbStack bind mounts.
+#   - In CI (V86_WORK_DIR set): a host path bind mount. CI runners are native
+#     Linux ext4, so the mtime bug doesn't apply, and a host path lets
+#     actions/cache persist the compiled toolchain + packages across runs.
+if [[ -n "${V86_WORK_DIR:-}" ]]; then
+  mkdir -p "$V86_WORK_DIR"
+  work_mount_src="$(cd "$V86_WORK_DIR" && pwd)"
+  echo "==> Using bind-mounted work tree: ${work_mount_src}"
+else
+  docker volume create "$work_volume" >/dev/null
+  work_mount_src="$work_volume"
+fi
 
 echo "==> Building Docker builder image"
 docker build \
@@ -38,16 +52,16 @@ docker build \
   -t "$image_tag" \
   "$src_dir"
 
-echo "==> Running Buildroot build (tree in volume ${work_volume}, dl cache in ${dl_dir})"
+echo "==> Running Buildroot build (tree in ${work_mount_src}, dl cache in ${dl_dir})"
 # Docker initialises named volumes as root:root; hand it to the unprivileged
 # builder uid/gid so the in-container build (which must not run as root) can write.
-docker run --rm -u 0:0 --entrypoint chown -v "${work_volume}:/work" "$image_tag" \
+docker run --rm -u 0:0 --entrypoint chown -v "${work_mount_src}:/work" "$image_tag" \
   -R "$(id -u):$(id -g)" /work
 docker run --rm \
   -e "CLEAN_TARGET=${CLEAN_TARGET:-0}" \
   -e "BR_VERSION=${BR_VERSION:-}" \
   -v "${repo_root}/${src_dir}:/src:ro" \
-  -v "${work_volume}:/work" \
+  -v "${work_mount_src}:/work" \
   -v "${repo_root}/${dl_dir}:/dl" \
   -v "${repo_root}/${out_dir}:/out" \
   "$image_tag"


### PR DESCRIPTION
## Summary
Speeds up the emulator image CI and adds update automation.

### 1. CI Buildroot caching (~45 min → ~5-10 min warm)
Locally, image rebuilds are fast because the whole Buildroot tree (cross toolchain + compiled packages) persists in a Docker named volume. CI couldn't reuse that, so every run did a cold ~45 min build (recompiling glibc + Rust `bat`). Now:
- `build-v86-image.sh` honours `V86_WORK_DIR` to bind-mount the work tree to a host path instead of the named volume. The named volume is only needed locally to dodge the macOS/OrbStack `stamp.os`/virtiofs mtime bug — **CI runners are native Linux ext4, so that bug doesn't apply**.
- `build-v86-image.yml` caches `build/v86-image/work` with `actions/cache` and builds with `CLEAN_TARGET=1` (keeps compiled packages, always rebuilds the rootfs clean). A trim step drops the regeneratable `target/staging/images` before the cache saves, keeping the artifact lean.

> First build after merge is still cold (populates the cache); the speedup lands on the next image build.

### 2. Dependabot
Weekly PRs for GitHub Actions + npm dependencies (dev deps grouped).

### 3. Scheduled LTS kernel bump (gated by smoke test)
The kernel is deliberately pinned to 6.6.37 — newer kernels have hung under v86. New monthly workflow (`kernel-update.yml`):
- Finds the newest upstream **longterm (LTS)** kernel from kernel.org.
- If it differs from the pin, rebuilds the image on it and runs the **full boot + 9p smoke test**.
- Opens a PR **only when it actually boots** — so a human always vets the bump, and breakage never lands silently. Supports `workflow_dispatch` with a forced version.

## Verification
- `bash -n` on the build script; all three YAML files parse.
- Local default build path (named volume) unchanged — `V86_WORK_DIR` only alters CI.

Closes #70
