### PR TITLE
feat: add RSS feed for projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "website",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/rss": "4.0.19",
+        "@astrojs/rss": "^4.0.19",
         "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.0.7"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "website",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/rss": "4.0.19",
         "@astrojs/sitemap": "^3.7.3",
         "astro": "^7.0.7"
       },
@@ -313,6 +314,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.19.tgz",
+      "integrity": "sha512-e+z5wYeYtffQdHQO8c2tkSd2JEBdAuRXJV4ZEU5IxkYeE6e39woDd7nw1PH1Kk2tEYNCYuKdylnnbhGmt61awA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -1255,6 +1267,18 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
@@ -2947,6 +2971,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -4144,6 +4180,45 @@
         "fast-string-width": "^3.0.2"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
+      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4356,6 +4431,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -5137,6 +5224,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -5610,6 +5712,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/svgo": {
@@ -6629,6 +6746,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vp test"
   },
   "dependencies": {
+    "@astrojs/rss": "4.0.19",
     "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:watch": "vp test"
   },
   "dependencies": {
-    "@astrojs/rss": "4.0.19",
+    "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.3",
     "astro": "^7.0.7"
   },

--- a/src/lib/rss.test.ts
+++ b/src/lib/rss.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest';
+import { projectLink, projectPubDate, projectsToRssItems, siteWithBase } from './rss';
+import type { ProjectInput } from './manifest';
+
+const projects: ProjectInput[] = [
+  { id: '2016-telephone-booth', data: { title: 'Telephone Booth', year: 2016, summary: 'Phone.' } },
+  { id: 'ongoing-foundsounds', data: { title: 'Ongoing - FoundSounds', summary: 'Social.' } },
+  { id: '2026-telephone-booth', data: { title: "Telephone Booth (St. Anne's)", year: 2026 } },
+];
+
+test('project RSS items use files routes in manifest order', () => {
+  expect(projectsToRssItems(projects)).toMatchObject([
+    { title: 'Ongoing - FoundSounds', link: 'files/projects/ongoing-foundsounds' },
+    { title: "Telephone Booth (St. Anne's)", link: 'files/projects/2026-telephone-booth' },
+    { title: 'Telephone Booth', link: 'files/projects/2016-telephone-booth' },
+  ]);
+});
+
+test('project RSS dates come from the project year when present', () => {
+  expect(projectPubDate(projects[0])?.toISOString()).toBe('2016-01-01T00:00:00.000Z');
+  expect(projectPubDate(projects[1])).toBeUndefined();
+});
+
+test('project RSS links and site URL honor Astro base paths', () => {
+  expect(projectLink(projects[0])).toBe('files/projects/2016-telephone-booth');
+  expect(siteWithBase(new URL('https://example.com'), '/website/').href).toBe(
+    'https://example.com/website/',
+  );
+});

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,0 +1,27 @@
+import type { RSSFeedItem } from '@astrojs/rss';
+import { sortProjects, type ProjectInput } from './manifest';
+
+export const feedTitle = 'David Jensenius';
+export const feedDescription =
+  'Projects and writing by David Jensenius, composer and media artist.';
+
+export function siteWithBase(site: URL, base: string): URL {
+  return new URL(base, site);
+}
+
+export function projectPubDate(project: ProjectInput): Date | undefined {
+  return project.data.year ? new Date(Date.UTC(project.data.year, 0, 1)) : undefined;
+}
+
+export function projectLink(project: ProjectInput): string {
+  return `files/projects/${project.id}`;
+}
+
+export function projectsToRssItems<T extends ProjectInput>(projects: T[]): RSSFeedItem[] {
+  return sortProjects(projects).map((project) => ({
+    title: project.data.title,
+    description: project.data.summary,
+    link: projectLink(project),
+    pubDate: projectPubDate(project),
+  }));
+}

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -2,8 +2,7 @@ import type { RSSFeedItem } from '@astrojs/rss';
 import { sortProjects, type ProjectInput } from './manifest';
 
 export const feedTitle = 'David Jensenius';
-export const feedDescription =
-  'Projects and writing by David Jensenius, composer and media artist.';
+export const feedDescription = 'Projects by David Jensenius, composer and media artist.';
 
 export function siteWithBase(site: URL, base: string): URL {
   return new URL(base, site);

--- a/src/pages/files/index.astro
+++ b/src/pages/files/index.astro
@@ -12,6 +12,7 @@ import '../../styles/file-view.css';
 
 const base = import.meta.env.BASE_URL;
 const bioHref = `${base}files/info/bio`.replace(/\/{2,}/g, '/');
+const rssHref = `${base}rss.xml`.replace(/\/{2,}/g, '/');
 const title = 'Files — David Jensenius';
 const description =
   'Browse the work, biography, and projects of David Jensenius, composer and media artist.';
@@ -23,6 +24,7 @@ const description =
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <BaseHead title={title} description={description} path="/files/" />
+    <link rel="alternate" type="application/rss+xml" title="David Jensenius RSS" href={rssHref} />
   </head>
   <body data-base={base}>
     <div class="modebar">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import Emulator from '../components/Emulator.astro';
 import ModeToggle from '../components/ModeToggle.astro';
 const title = 'David Jensenius';
 const description = 'The work and portfolio of David Jensenius, composer and media artist.';
+const rssHref = `${import.meta.env.BASE_URL}rss.xml`.replace(/\/{2,}/g, '/');
 ---
 
 <!doctype html>
@@ -16,6 +17,7 @@ const description = 'The work and portfolio of David Jensenius, composer and med
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <BaseHead title={title} description={description} path="/" />
+    <link rel="alternate" type="application/rss+xml" title="David Jensenius RSS" href={rssHref} />
   </head>
   <body>
     <div class="shell">

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,14 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import { feedDescription, feedTitle, projectsToRssItems, siteWithBase } from '../lib/rss';
+
+export async function GET(context: { site: URL }) {
+  const projects = await getCollection('projects');
+
+  return rss({
+    title: feedTitle,
+    description: feedDescription,
+    site: siteWithBase(context.site, import.meta.env.BASE_URL),
+    items: projectsToRssItems(projects),
+  });
+}

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,14 +1,19 @@
 import rss from '@astrojs/rss';
+import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import { feedDescription, feedTitle, projectsToRssItems, siteWithBase } from '../lib/rss';
 
-export async function GET(context: { site: URL }) {
+export const GET: APIRoute = async ({ site }) => {
+  if (!site) {
+    return new Response('RSS feed requires the Astro site config to be set.', { status: 500 });
+  }
+
   const projects = await getCollection('projects');
 
   return rss({
     title: feedTitle,
     description: feedDescription,
-    site: siteWithBase(context.site, import.meta.env.BASE_URL),
+    site: siteWithBase(site, import.meta.env.BASE_URL),
     items: projectsToRssItems(projects),
   });
-}
+};


### PR DESCRIPTION
## Summary
- add @astrojs/rss and generate /rss.xml from the projects content collection
- reuse the site project ordering for RSS items and link to Files routes
- add RSS discovery links on the home and Files pages

Closes #25

## Validation
- npx vp fmt
- just fmt-check && just lint && just type-check && just test && just build