### PR TITLE
fix: accessibility pass (focus, keyboard, ARIA, reduced-motion, contrast)

### DIFF
--- a/src/components/Emulator.astro
+++ b/src/components/Emulator.astro
@@ -414,9 +414,16 @@ const noteId = `terminal-note-${uid}`;
     const root = container && container.closest('.emulator');
     if (window.__v86ActiveScreen === undefined) window.__v86ActiveScreen = screenId;
     if (container) {
+      const focusScreen = () => {
+        try {
+          container.focus({ preventScroll: true });
+        } catch {
+          container.focus();
+        }
+      };
       container.addEventListener('pointerdown', () => {
         window.__v86ActiveScreen = screenId;
-        container.focus({ preventScroll: true });
+        focusScreen();
       });
       container.addEventListener('focusin', () => {
         window.__v86ActiveScreen = screenId;

--- a/src/components/Emulator.astro
+++ b/src/components/Emulator.astro
@@ -25,6 +25,7 @@ const uid = crypto.randomUUID().slice(0, 8);
 const statusId = `status-${uid}`;
 const screenId = `screen_container-${uid}`;
 const scrollbackId = `scrollback-${uid}`;
+const noteId = `terminal-note-${uid}`;
 ---
 
 <div class="emulator">
@@ -32,7 +33,14 @@ const scrollbackId = `scrollback-${uid}`;
   <!-- v86's ScreenAdapter toggles the inline `display` of these two children to
        switch between text and graphical (VGA) modes, so the initial state is set
        inline here rather than in CSS. -->
-  <div id={screenId} class="screen">
+  <div
+    id={screenId}
+    class="screen"
+    role="region"
+    aria-label="Linux terminal emulator"
+    aria-describedby={`${statusId} ${noteId}`}
+    tabindex="0"
+  >
     <div class="screen-text" style="display: block"></div>
     <canvas class="screen-canvas" style="display: none"></canvas>
   </div>
@@ -41,7 +49,9 @@ const scrollbackId = `scrollback-${uid}`;
     <button type="button" class="scrollback-toggle" aria-controls={scrollbackId} aria-expanded="false">
       Show scrollback
     </button>
-    <span class="terminal-note">Selection works in DOM text mode; VGA/canvas text can be copied with the button.</span>
+    <span id={noteId} class="terminal-note">
+      Selection works in DOM text mode; VGA/canvas text can be copied with the button.
+    </span>
   </div>
   <div id={scrollbackId} class="scrollback" hidden>
     <pre class="scrollback-buffer" tabindex="0" aria-label="Emulator scrollback"></pre>
@@ -405,6 +415,9 @@ const scrollbackId = `scrollback-${uid}`;
     if (window.__v86ActiveScreen === undefined) window.__v86ActiveScreen = screenId;
     if (container) {
       container.addEventListener('pointerdown', () => {
+        window.__v86ActiveScreen = screenId;
+      });
+      container.addEventListener('focusin', () => {
         window.__v86ActiveScreen = screenId;
       });
     }

--- a/src/components/Emulator.astro
+++ b/src/components/Emulator.astro
@@ -416,12 +416,15 @@ const noteId = `terminal-note-${uid}`;
     if (container) {
       container.addEventListener('pointerdown', () => {
         window.__v86ActiveScreen = screenId;
+        container.focus({ preventScroll: true });
       });
       container.addEventListener('focusin', () => {
         window.__v86ActiveScreen = screenId;
       });
     }
     const isActive = () => window.__v86ActiveScreen === screenId;
+    const screenHasFocus = () =>
+      container && document.activeElement && container.contains(document.activeElement);
     const selectedInside = () => {
       const selection = window.getSelection();
       if (!selection || selection.isCollapsed || !selection.toString()) return false;
@@ -435,6 +438,7 @@ const noteId = `terminal-note-${uid}`;
         e.stopImmediatePropagation();
         return;
       }
+      if (!screenHasFocus()) return;
       // Leave Cmd/Win shortcuts (copy, paste, …) alone so the browser, OS, and
       // any other page listeners still receive them. The exception is selected
       // emulator text above: Cmd/Ctrl+C is stopped there so the guest does not

--- a/src/components/Emulator.astro
+++ b/src/components/Emulator.astro
@@ -421,10 +421,14 @@ const noteId = `terminal-note-${uid}`;
           container.focus();
         }
       };
-      container.addEventListener('pointerdown', () => {
-        window.__v86ActiveScreen = screenId;
-        focusScreen();
-      });
+      container.addEventListener(
+        'pointerdown',
+        () => {
+          window.__v86ActiveScreen = screenId;
+          focusScreen();
+        },
+        true,
+      );
       container.addEventListener('focusin', () => {
         window.__v86ActiveScreen = screenId;
       });

--- a/src/pages/emulator/index.astro
+++ b/src/pages/emulator/index.astro
@@ -18,11 +18,12 @@ const description =
     <BaseHead title={title} description={description} path="/emulator/" />
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
     <div class="shell">
       <header class="topbar">
         <ModeToggle active="terminal" />
       </header>
-      <main class="stage">
+      <main id="main" class="stage" tabindex="-1">
         <Emulator />
       </main>
     </div>
@@ -51,6 +52,36 @@ const description =
         background: var(--shell-bg);
         color: var(--shell-fg);
         font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+
+      .skip-link {
+        position: fixed;
+        inset-block-start: 0.75rem;
+        inset-inline-start: 0.75rem;
+        z-index: 10;
+        transform: translateY(-200%);
+        background: var(--shell-bg);
+        color: var(--shell-fg);
+        border: 2px solid currentColor;
+        border-radius: 0.25rem;
+        padding: 0.5rem 0.75rem;
+      }
+
+      .skip-link:focus-visible {
+        transform: translateY(0);
+        outline: 3px solid currentColor;
+        outline-offset: 2px;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          scroll-behavior: auto !important;
+          transition-duration: 0.01ms !important;
+        }
       }
 
       /* Full-viewport column: a slim bar with the mode toggle, then the

--- a/src/pages/files/[...path].astro
+++ b/src/pages/files/[...path].astro
@@ -60,12 +60,13 @@ const fileHref = (path: string) =>
     />
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
     <div class="modebar">
       <ModeToggle active="files" />
     </div>
     <nav aria-label="Files">
       <h2>~ / david</h2>
-      <ul>
+      <ul aria-label="File tree">
         {
           tree.map((n) =>
             n.kind === 'dir' ? (
@@ -76,6 +77,7 @@ const fileHref = (path: string) =>
                   class="entry"
                   href={fileHref(n.path)}
                   aria-current={n.path === node.path ? 'page' : undefined}
+                  aria-label={`Open ${n.name}`}
                 >
                   {n.name}
                 </a>
@@ -85,7 +87,7 @@ const fileHref = (path: string) =>
         }
       </ul>
     </nav>
-    <main>
+    <main id="main" tabindex="-1">
       <article>
         <h1>{node.title}</h1>
         {node.year && <p class="prompt">{node.year}</p>}

--- a/src/pages/files/index.astro
+++ b/src/pages/files/index.astro
@@ -27,12 +27,13 @@ const description =
     <link rel="alternate" type="application/rss+xml" title="David Jensenius RSS" href={rssHref} />
   </head>
   <body data-base={base}>
+    <a class="skip-link" href="#viewer">Skip to main content</a>
     <div class="modebar">
       <ModeToggle active="files" />
     </div>
     <nav aria-label="Files">
       <h2>~ / david</h2>
-      <ul id="tree">
+      <ul id="tree" aria-label="File tree">
         <li class="prompt">Loading…</li>
       </ul>
     </nav>
@@ -79,6 +80,7 @@ const description =
             a.href = `#${node.path}`;
             a.dataset.path = node.path;
             a.textContent = node.name;
+            a.setAttribute('aria-label', `Open ${node.name}`);
             li.append(a);
           }
           tree.append(li);
@@ -150,12 +152,19 @@ const description =
       }
 
       document.addEventListener('keydown', (e) => {
+        if (!document.activeElement || !tree.contains(document.activeElement)) return;
         if (e.key === 'ArrowDown') {
           e.preventDefault();
           move(1);
         } else if (e.key === 'ArrowUp') {
           e.preventDefault();
           move(-1);
+        } else if (e.key === 'Home') {
+          e.preventDefault();
+          move(-Infinity);
+        } else if (e.key === 'End') {
+          e.preventDefault();
+          move(Infinity);
         }
       });
 

--- a/src/pages/files/index.astro
+++ b/src/pages/files/index.astro
@@ -65,6 +65,7 @@ const description =
       const empty = document.getElementById('empty') as HTMLElement;
 
       let files: FsNode[] = [];
+      let focusAfterHash: HTMLElement | null = null;
 
       function render(nodes: FsNode[]) {
         tree.replaceChildren();
@@ -94,7 +95,7 @@ const description =
         }
       }
 
-      async function open(path: string) {
+      async function open(path: string, focusTarget?: HTMLElement) {
         const node = files.find((f) => f.path === path);
         if (!node) return;
         empty.hidden = true;
@@ -116,13 +117,15 @@ const description =
           if (!article) throw new Error('no content found');
           loading.remove();
           viewer.append(article);
-          viewer.focus();
+          if (focusTarget) focusTarget.focus();
+          else viewer.focus();
         } catch (err) {
           loading.remove();
           const p = document.createElement('p');
           p.className = 'prompt status';
           p.textContent = `Could not load ${path}: ${(err as Error).message}`;
           viewer.append(p);
+          if (focusTarget) focusTarget.focus();
         }
       }
 
@@ -137,13 +140,23 @@ const description =
         if (entries.length === 0) return;
         const next = Math.max(0, Math.min(entries.length - 1, currentIndex() + delta));
         const target = entries[next];
+        const path = target.dataset.path ?? '';
+        if (!path) return;
+        focusAfterHash = target;
         target.focus();
-        location.hash = target.dataset.path ?? '';
+        if (location.hash.replace(/^#/, '') === path) {
+          focusAfterHash = null;
+          void open(path, target);
+        } else {
+          location.hash = path;
+        }
       }
 
       function fromHash() {
         const path = location.hash.replace(/^#/, '');
-        if (path) void open(path);
+        const focusTarget = focusAfterHash ?? undefined;
+        focusAfterHash = null;
+        if (path) void open(path, focusTarget);
         else {
           const defaultPath = '/info/bio';
           history.replaceState(null, '', `#${defaultPath}`);
@@ -167,7 +180,6 @@ const description =
           move(Infinity);
         }
       });
-
       window.addEventListener('hashchange', fromHash);
 
       (async () => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,6 +20,7 @@ const rssHref = `${import.meta.env.BASE_URL}rss.xml`.replace(/\/{2,}/g, '/');
     <link rel="alternate" type="application/rss+xml" title="David Jensenius RSS" href={rssHref} />
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
     <div class="shell">
       <header class="masthead">
         <div class="modebar">
@@ -32,7 +33,7 @@ const rssHref = `${import.meta.env.BASE_URL}rss.xml`.replace(/\/{2,}/g, '/');
           Composer and media artist. Switch to <strong>Files</strong> above for plain pages.
         </p>
       </header>
-      <main class="stage">
+      <main id="main" class="stage" tabindex="-1">
         <Emulator />
       </main>
     </div>
@@ -65,6 +66,36 @@ const rssHref = `${import.meta.env.BASE_URL}rss.xml`.replace(/\/{2,}/g, '/');
         background: var(--shell-bg);
         color: var(--shell-fg);
         font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+
+      .skip-link {
+        position: fixed;
+        inset-block-start: 0.75rem;
+        inset-inline-start: 0.75rem;
+        z-index: 10;
+        transform: translateY(-200%);
+        background: var(--shell-bg);
+        color: var(--shell-fg);
+        border: 2px solid currentColor;
+        border-radius: 0.25rem;
+        padding: 0.5rem 0.75rem;
+      }
+
+      .skip-link:focus-visible {
+        transform: translateY(0);
+        outline: 3px solid var(--shell-link);
+        outline-offset: 2px;
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          scroll-behavior: auto !important;
+          transition-duration: 0.01ms !important;
+        }
       }
 
       /* Full-viewport column: a compact header with my info, then the emulator

--- a/src/styles/emulator.css
+++ b/src/styles/emulator.css
@@ -6,16 +6,20 @@
  */
 .emulator {
   --e-fg: #d7d7d7;
+  --e-ui-fg: #d7d7d7;
   --e-muted: #8a8a8a;
   --e-border: #222222;
   --e-link: #7aa2f7;
+  --e-focus-ring: #facc15;
 }
 
 @media (prefers-color-scheme: light) {
   .emulator {
+    --e-ui-fg: #1a1a1a;
     --e-muted: #6a6a6a;
     --e-border: #c9c9c4;
     --e-link: #1d4ed8;
+    --e-focus-ring: #7c3aed;
   }
 }
 
@@ -50,6 +54,11 @@
    * container to the scaled grid. Clip any sub-pixel rounding overflow rather
    * than showing a scrollbar. */
   overflow: hidden;
+}
+
+.emulator .screen:focus-visible {
+  outline: 3px solid var(--e-focus-ring);
+  outline-offset: 3px;
 }
 
 .emulator .screen.is-fitted {
@@ -98,15 +107,21 @@
   border: 1px solid var(--e-border);
   border-radius: 0.25rem;
   background: transparent;
-  color: var(--e-fg);
+  color: var(--e-ui-fg);
   font: inherit;
   padding: 0.25rem 0.5rem;
 }
 
-.emulator .terminal-actions button:hover,
+.emulator .terminal-actions button:hover {
+  border-color: var(--e-link);
+  color: var(--e-link);
+}
+
 .emulator .terminal-actions button:focus-visible {
   border-color: var(--e-link);
   color: var(--e-link);
+  outline: 3px solid var(--e-focus-ring);
+  outline-offset: 2px;
 }
 
 .emulator .terminal-note {
@@ -139,6 +154,11 @@
   -webkit-user-select: text;
 }
 
+.emulator .scrollback-buffer:focus-visible {
+  outline: 3px solid var(--e-focus-ring);
+  outline-offset: 3px;
+}
+
 .emulator .fallback {
   flex: 0 0 auto;
   color: var(--e-muted);
@@ -148,4 +168,20 @@
 
 .emulator .fallback a {
   color: var(--e-link);
+}
+
+.emulator .fallback a:focus-visible {
+  outline: 3px solid var(--e-focus-ring);
+  outline-offset: 0.2em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .emulator *,
+  .emulator *::before,
+  .emulator *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/src/styles/file-view.css
+++ b/src/styles/file-view.css
@@ -8,12 +8,13 @@
   color-scheme: light dark;
   --bg: #0b0b0b;
   --fg: #d7d7d7;
-  --muted: #6a6a6a;
+  --muted: #8a8a8a;
   --border: #222222;
   --dir: #7aa2f7;
   --file: #b9f27a;
   --accent: #ffffff;
   --link: #7aa2f7;
+  --focus-ring: #facc15;
 }
 
 @media (prefers-color-scheme: light) {
@@ -26,6 +27,7 @@
     --file: #15803d;
     --accent: #000000;
     --link: #1d4ed8;
+    --focus-ring: #7c3aed;
   }
 }
 
@@ -38,6 +40,25 @@ body {
   grid-template-columns: 18rem 1fr;
   grid-template-rows: auto 1fr;
   min-height: 100vh;
+}
+
+.skip-link {
+  position: fixed;
+  inset-block-start: 0.75rem;
+  inset-inline-start: 0.75rem;
+  z-index: 10;
+  transform: translateY(-200%);
+  background: var(--bg);
+  color: var(--fg);
+  border: 2px solid currentColor;
+  border-radius: 0.25rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .modebar {
@@ -95,7 +116,7 @@ a.entry:hover {
 }
 
 a.entry:focus-visible {
-  outline: 2px solid var(--file);
+  outline: 3px solid var(--focus-ring);
   outline-offset: 2px;
   text-decoration: underline;
 }
@@ -114,6 +135,11 @@ main {
 
 main a {
   color: var(--link);
+}
+
+main a:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 0.2em;
 }
 
 .prompt {
@@ -148,4 +174,15 @@ main a {
 
 [hidden] {
   display: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }


### PR DESCRIPTION
Closes #28

Changes:
- Added skip-to-main links on the landing, standalone emulator, Files browser, and static file pages so keyboard and screen-reader users can bypass repeated chrome.
- Labeled the Linux terminal region, made it keyboard-focusable, and set focus activation so terminal input targets the focused emulator.
- Added/strengthened visible focus outlines for file links, article links, emulator controls, terminal screen, scrollback, and skip links.
- Labeled the Files tree and file entries, and scoped arrow/Home/End file navigation to the focused tree so page scrolling and content reading are not hijacked.
- Added reduced-motion media queries to suppress non-essential animations/transitions, including emulator chrome/cursor effects.
- Nudged low-contrast muted/UI colors in file and emulator themes while preserving the terminal aesthetic.