### PR TITLE
fix: emulator host-keyboard focus + linkable Files tagline

### DIFF
--- a/src/components/Emulator.astro
+++ b/src/components/Emulator.astro
@@ -128,6 +128,23 @@ const noteId = `terminal-note-${uid}`;
       if (/[#$%]\s$/.test(buffer)) {
         greeted = true;
         setStatus('System ready');
+        // Focus the terminal screen once the shell is up so keystrokes are
+        // captured by our layout-aware handler (which re-injects the host's
+        // actual characters — Colemak, AltGr, etc.) instead of falling through
+        // to v86's US position mapping. Only take focus if the user hasn't
+        // already moved it elsewhere (e.g. tabbed to a button), so the a11y
+        // focus model still holds.
+        const screenContainer = document.getElementById(screenId);
+        if (screenContainer && window.__v86ActiveScreen === screenId) {
+          const active = document.activeElement;
+          if (!active || active === document.body) {
+            try {
+              screenContainer.focus({ preventScroll: true });
+            } catch {
+              screenContainer.focus();
+            }
+          }
+        }
         // The browser shows the VGA text console (the interactive shell the user
         // sees and types into), while serial0 is only used here to detect that
         // the shell is up. So inject the deep-link command as *keyboard* input so

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import ModeToggle from '../components/ModeToggle.astro';
 const title = 'David Jensenius';
 const description = 'The work and portfolio of David Jensenius, composer and media artist.';
 const rssHref = `${import.meta.env.BASE_URL}rss.xml`.replace(/\/{2,}/g, '/');
+const filesHref = `${import.meta.env.BASE_URL}/files/`.replace(/\/{2,}/g, '/');
 ---
 
 <!doctype html>
@@ -32,7 +33,8 @@ const rssHref = `${import.meta.env.BASE_URL}rss.xml`.replace(/\/{2,}/g, '/');
           <h1>{title}</h1>
         </div>
         <p class="tagline">
-          Composer and media artist. Switch to <strong>Files</strong> above for plain pages.
+          Composer and media artist. Switch to
+          <a class="files-link" href={filesHref}><strong>Files</strong></a> above for plain pages.
         </p>
       </header>
       <main id="main" class="stage" tabindex="-1">


### PR DESCRIPTION
Two small landing/emulator UX fixes.

## Terminal keyboard layout regression
The a11y pass (#73) gated the emulator keyboard handler on the terminal screen holding DOM focus. On load the screen wasn't focused, so our layout-aware handler (which re-injects the host's actual characters for Colemak/AltGr/etc. via `keyboard_send_text`) was skipped and keys fell through to v86's US position mapping — breaking non-QWERTY layouts. Now the screen auto-focuses once the shell is ready, but only if the user hasn't already moved focus elsewhere, so the a11y focus model still holds.

## Linkable 'Files' tagline
The landing tagline said "Switch to **Files** above" but the word wasn't a link. It now links to the Files view (same target as the mode toggle).

## Verification
`just fmt-check`, `just lint`, `just type-check`, `just build` all pass. Keyboard change is client-side only (no image rebuild).