### PR TITLE
feat: optional self-host container for the DeskPi rack (#38)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Keep the Docker build context small and reproducible. The image runs `npm ci`
+# and fetches the emulator binaries itself, so local installs/artifacts are
+# excluded — the lockfile in git is the source of truth.
+.git
+node_modules
+dist
+.astro
+
+# Local env / editor / OS cruft
+.env
+.env.*
+!.env.example
+.DS_Store
+
+# Uncommitted emulator binaries — the Dockerfile pulls these from the public
+# release during the build, so any local copies shouldn't bloat the context.
+public/emulator/v86/buildroot-bzimage.bin
+public/emulator/v86/buildroot-initrd.bin
+
+# Heavy build tooling not needed to build the static site.
+scripts/v86-image
+root
+root.bin
+jslinux-mobile

--- a/Caddyfile
+++ b/Caddyfile
@@ -12,8 +12,21 @@
 
 	file_server
 
-	# Long-cache the fingerprinted build assets and the large emulator payloads;
-	# HTML stays uncached so content updates show up immediately.
-	@immutable path /_astro/* /emulator/v86/*
-	header @immutable Cache-Control "public, max-age=31536000, immutable"
+	# Cache policy, keyed to whether the URL is content-addressed:
+	#   * /_astro/* — Astro fingerprints these filenames, so cache forever.
+	#   * /emulator/v86/* — large but NOT fingerprinted (fs.json, kernel, initrd),
+	#     so cache modestly (1 day) to pick up release updates without refetching
+	#     ~24 MB on every visit.
+	#   * everything else (HTML/clean URLs) — revalidate so content edits show up
+	#     immediately.
+	# The three matchers are mutually exclusive, so each response gets exactly one
+	# Cache-Control.
+	@fingerprinted path /_astro/*
+	header @fingerprinted Cache-Control "public, max-age=31536000, immutable"
+
+	@emulator_assets path /emulator/v86/*
+	header @emulator_assets Cache-Control "public, max-age=86400"
+
+	@dynamic not path /_astro/* /emulator/v86/*
+	header @dynamic Cache-Control "no-cache"
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,19 @@
+# Caddy config for the self-host container (issue #38). Serves the static Astro
+# build from /srv with clean URLs and compression. Production stays on GitHub
+# Pages (#30); this is an optional rack backup.
+:80 {
+	root * /srv
+
+	encode gzip zstd
+
+	# Astro emits directory-style routes (e.g. /files/index.html). try_files
+	# resolves clean URLs to the matching .html / index.html Astro generated.
+	try_files {path} {path}/ {path}.html {path}/index.html
+
+	file_server
+
+	# Long-cache the fingerprinted build assets and the large emulator payloads;
+	# HTML stays uncached so content updates show up immediately.
+	@immutable path /_astro/* /emulator/v86/*
+	header @immutable Cache-Control "public, max-age=31536000, immutable"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+# Self-host container for the modernized site (issue #38).
+#
+# Optional backup/experiment host for the DeskPi rack — production stays on
+# GitHub Pages (#30). Multi-stage: build the static Astro site with Node, then
+# serve the plain `dist/` output with Caddy (clean URLs + gzip, no Node runtime).
+#
+# The emulator's Buildroot binaries (~24 MB) are not committed to git; they are
+# pulled from the public `emulator-image` release at build time (no auth needed
+# because the repo is public). Override V86_IMAGE_REPO / V86_IMAGE_TAG to build
+# from a fork or a different release.
+#
+#   docker build -t djensenius-website .
+#   docker run --rm -p 8080:80 djensenius-website   # http://localhost:8080
+
+# ---- Stage 1: build the static site -----------------------------------------
+FROM node:26-slim AS build
+
+# SITE_URL/BASE_PATH feed Astro's `site`/`base`. Defaults suit a root-served
+# self-host; the GitHub Pages deploy passes its own values.
+ARG SITE_URL=https://jensenius.com
+ARG BASE_PATH=/
+ARG V86_IMAGE_REPO=djensenius/website
+ARG V86_IMAGE_TAG=emulator-image
+ENV SITE_URL=${SITE_URL} \
+    BASE_PATH=${BASE_PATH}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install dependencies against the lockfile first for better layer caching.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Bring in the rest of the source and build.
+COPY . .
+
+# Fetch the uncommitted emulator kernel/initrd from the public release so the
+# terminal actually boots in the served site.
+RUN base="https://github.com/${V86_IMAGE_REPO}/releases/download/${V86_IMAGE_TAG}" \
+    && mkdir -p public/emulator/v86 \
+    && for f in buildroot-bzimage.bin buildroot-initrd.bin; do \
+         echo "==> Fetching ${f}"; \
+         curl -fsSL "${base}/${f}" -o "public/emulator/v86/${f}"; \
+         test -s "public/emulator/v86/${f}"; \
+       done
+
+RUN npm run build
+
+# ---- Stage 2: serve the static output ---------------------------------------
+FROM caddy:2-alpine AS runtime
+
+COPY Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /app/dist /srv
+
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN base="https://github.com/${V86_IMAGE_REPO}/releases/download/${V86_IMAGE_TAG
     && for pair in "buildroot-bzimage.bin:${V86_BZIMAGE_SHA256}" "buildroot-initrd.bin:${V86_INITRD_SHA256}"; do \
          f="${pair%%:*}"; sha="${pair#*:}"; \
          echo "==> Fetching ${f}"; \
-         curl -fsSL "${base}/${f}" -o "public/emulator/v86/${f}"; \
+         curl --retry 5 --retry-delay 2 --retry-all-errors -fsSL "${base}/${f}" -o "public/emulator/v86/${f}"; \
          test -s "public/emulator/v86/${f}"; \
          if [ -n "$sha" ]; then \
            echo "${sha}  public/emulator/v86/${f}" | sha256sum -c -; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,19 @@ ARG SITE_URL=https://jensenius.com
 ARG BASE_PATH=/
 ARG V86_IMAGE_REPO=djensenius/website
 ARG V86_IMAGE_TAG=emulator-image
+# Optional SHA-256 pins for the fetched emulator binaries. Leave empty to accept
+# whatever the rolling release currently serves; set them to make the build
+# reproducible and reject tampered/corrupt downloads.
+ARG V86_BZIMAGE_SHA256=
+ARG V86_INITRD_SHA256=
+# Opt-in Plausible analytics (see README > Analytics). PUBLIC_* vars are read by
+# Astro at build time; empty by default so nothing is emitted.
+ARG PUBLIC_PLAUSIBLE_DOMAIN=
+ARG PUBLIC_PLAUSIBLE_SRC=
 ENV SITE_URL=${SITE_URL} \
-    BASE_PATH=${BASE_PATH}
+    BASE_PATH=${BASE_PATH} \
+    PUBLIC_PLAUSIBLE_DOMAIN=${PUBLIC_PLAUSIBLE_DOMAIN} \
+    PUBLIC_PLAUSIBLE_SRC=${PUBLIC_PLAUSIBLE_SRC}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \
@@ -38,13 +49,19 @@ RUN npm ci
 COPY . .
 
 # Fetch the uncommitted emulator kernel/initrd from the public release so the
-# terminal actually boots in the served site.
+# terminal actually boots in the served site. If a matching *_SHA256 build arg
+# is set, the download is verified (reproducible / tamper-evident); otherwise
+# the current release asset is accepted as-is.
 RUN base="https://github.com/${V86_IMAGE_REPO}/releases/download/${V86_IMAGE_TAG}" \
     && mkdir -p public/emulator/v86 \
-    && for f in buildroot-bzimage.bin buildroot-initrd.bin; do \
+    && for pair in "buildroot-bzimage.bin:${V86_BZIMAGE_SHA256}" "buildroot-initrd.bin:${V86_INITRD_SHA256}"; do \
+         f="${pair%%:*}"; sha="${pair#*:}"; \
          echo "==> Fetching ${f}"; \
          curl -fsSL "${base}/${f}" -o "public/emulator/v86/${f}"; \
          test -s "public/emulator/v86/${f}"; \
+         if [ -n "$sha" ]; then \
+           echo "${sha}  public/emulator/v86/${f}" | sha256sum -c -; \
+         fi; \
        done
 
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ release automatically (no auth needed), so the terminal boots in the served site
 Configuration (all optional, via env or compose args):
 
 - `SITE_URL` — Astro `site` (default `https://jensenius.com`); sets canonical/sitemap URLs.
-- `BASE_PATH` — Astro `base` (default `/` for root-served self-host).
+- `BASE_PATH` — Astro `base` (default `/`). **Keep this `/` for the bundled Caddy
+  config, which serves the site at the container root.** A non-root value (e.g.
+  `/website/`) only works if you put a reverse proxy in front that strips the prefix —
+  the container itself does not, so `/website/...` requests would 404.
 - `HTTP_PORT` — host port to publish (default `8080`).
 - `V86_IMAGE_REPO` / `V86_IMAGE_TAG` — where to fetch the emulator binaries from
   (default `djensenius/website` / `emulator-image`); point at a fork or pin an

--- a/README.md
+++ b/README.md
@@ -87,9 +87,16 @@ Configuration (all optional, via env or compose args):
 - `SITE_URL` — Astro `site` (default `https://jensenius.com`); sets canonical/sitemap URLs.
 - `BASE_PATH` — Astro `base` (default `/` for root-served self-host).
 - `HTTP_PORT` — host port to publish (default `8080`).
+- `V86_IMAGE_REPO` / `V86_IMAGE_TAG` — where to fetch the emulator binaries from
+  (default `djensenius/website` / `emulator-image`); point at a fork or pin an
+  immutable release tag.
+- `V86_BZIMAGE_SHA256` / `V86_INITRD_SHA256` — optional SHA-256 pins; when set, the
+  downloaded binaries are verified so the build is reproducible and tamper-evident.
+- `PUBLIC_PLAUSIBLE_DOMAIN` / `PUBLIC_PLAUSIBLE_SRC` — opt-in Plausible analytics
+  (see **Analytics** above); empty by default so nothing is emitted.
 
-To enable Plausible analytics in the container, pass `PUBLIC_PLAUSIBLE_DOMAIN` (and
-optionally `PUBLIC_PLAUSIBLE_SRC`) as build args — see **Analytics** above.
+These are wired through `docker-compose.yml`, so a `.env` file next to it (or exported
+shell vars) is picked up automatically by `just serve` / `docker compose up`.
 
 ## WASM emulator (v86)
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ just v86-fetch  # download the prebuilt v86 emulator image from the emulator-ima
 just v86-image  # rebuild the v86 emulator image from source (Dockerized, long)
 just v86-fs     # regenerate the v86 WASM emulator filesystem from Markdown (#37)
 just v86-smoke  # boot the v86 emulator headless and verify content mounts (#37)
-just serve      # run the self-host container — WIP (#38)
+just serve      # build & run the optional self-host container (Docker, #38)
 ```
 
 ## Analytics
@@ -64,6 +64,32 @@ subpath deploys. Empty or unset `PUBLIC_PLAUSIBLE_SRC` defaults to
 For GitHub Pages deploys, these public build-time environment variables can be added to the
 build step in [`.github/workflows/deploy-preview.yml`](.github/workflows/deploy-preview.yml).
 Do not hardcode a domain in source.
+
+## Self-hosting (optional)
+
+Production is served from **GitHub Pages** (#30). As an optional backup/experiment, the
+site can also run as a container on the DeskPi rack (issue #38). It's a multi-stage build:
+Node builds the static Astro output, then [Caddy](https://caddyserver.com/) serves plain
+`dist/` files with clean URLs and compression — no Node runtime in the final image.
+
+```bash
+just serve                     # docker compose up --build → http://localhost:8080
+# or directly:
+docker compose up -d --build   # detached
+docker compose down            # stop
+```
+
+The build fetches the uncommitted emulator kernel/initrd from the public `emulator-image`
+release automatically (no auth needed), so the terminal boots in the served site.
+
+Configuration (all optional, via env or compose args):
+
+- `SITE_URL` — Astro `site` (default `https://jensenius.com`); sets canonical/sitemap URLs.
+- `BASE_PATH` — Astro `base` (default `/` for root-served self-host).
+- `HTTP_PORT` — host port to publish (default `8080`).
+
+To enable Plausible analytics in the container, pass `PUBLIC_PLAUSIBLE_DOMAIN` (and
+optionally `PUBLIC_PLAUSIBLE_SRC`) as build args — see **Analytics** above.
 
 ## WASM emulator (v86)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# Self-host the modernized site on the DeskPi rack (issue #38). Optional backup;
+# production stays on GitHub Pages (#30).
+#
+#   docker compose up -d --build      # build + serve on http://<host>:8080
+#   docker compose down               # stop
+services:
+  web:
+    build:
+      context: .
+      # Root-served self-host defaults. Override to build for a subpath, e.g.
+      # BASE_PATH=/website, or point at a fork's emulator-image release.
+      args:
+        SITE_URL: ${SITE_URL:-https://jensenius.com}
+        BASE_PATH: ${BASE_PATH:-/}
+    image: djensenius-website
+    restart: unless-stopped
+    ports:
+      - '${HTTP_PORT:-8080}:80'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,20 @@ services:
   web:
     build:
       context: .
-      # Root-served self-host defaults. Override to build for a subpath, e.g.
-      # BASE_PATH=/website, or point at a fork's emulator-image release.
+      # All optional; defaults suit a root-served self-host. Set them in a .env
+      # file next to this compose file or in the environment before `up`.
       args:
         SITE_URL: ${SITE_URL:-https://jensenius.com}
         BASE_PATH: ${BASE_PATH:-/}
+        # Point at a fork's emulator-image release, or pin an immutable tag.
+        V86_IMAGE_REPO: ${V86_IMAGE_REPO:-djensenius/website}
+        V86_IMAGE_TAG: ${V86_IMAGE_TAG:-emulator-image}
+        # Optional SHA-256 pins for the fetched emulator binaries.
+        V86_BZIMAGE_SHA256: ${V86_BZIMAGE_SHA256:-}
+        V86_INITRD_SHA256: ${V86_INITRD_SHA256:-}
+        # Opt-in Plausible analytics (see README > Analytics).
+        PUBLIC_PLAUSIBLE_DOMAIN: ${PUBLIC_PLAUSIBLE_DOMAIN:-}
+        PUBLIC_PLAUSIBLE_SRC: ${PUBLIC_PLAUSIBLE_SRC:-}
     image: djensenius-website
     restart: unless-stopped
     ports:

--- a/justfile
+++ b/justfile
@@ -84,6 +84,8 @@ v86-fs:
 v86-smoke:
     node scripts/v86-smoke.mjs
 
-# Serve the built site from the self-host container (see issue #38).
+# Build and run the optional self-host container (issue #38): builds the static
+# Astro site and serves dist/ with Caddy at http://localhost:8080. Production
+# stays on GitHub Pages; this is a rack backup/experiment. Requires Docker.
 serve:
-    @echo "TODO(#38): run the self-host container (Astro build -> nginx/caddy)."
+    docker compose up --build


### PR DESCRIPTION
Adds the **optional** self-host container from #38. Production stays on GitHub Pages (#30); this is a rack backup/experiment.

## What
Multi-stage Docker build: Node compiles the static Astro site, then [Caddy](https://caddyserver.com/) serves plain `dist/` files — no Node runtime in the final image.

- **Dockerfile** — `node:26-slim` build stage → `caddy:2-alpine` runtime. Fetches the uncommitted emulator kernel/initrd from the public `emulator-image` release at build time (no auth; repo is public), so the terminal boots in the served site.
- **Caddyfile** — `try_files` for Astro's clean/directory URLs, gzip+zstd, immutable caching for fingerprinted `/_astro/*` and the large `/emulator/v86/*` payloads (HTML stays uncached). No COOP/COEP so behaviour matches Pages.
- **docker-compose.yml** — one-command `up` on the rack; `SITE_URL` / `BASE_PATH` / `HTTP_PORT` configurable via env.
- **.dockerignore** — trims the build context (excludes local emulator bins, heavy `scripts/v86-image` tooling, legacy dirs).
- **justfile** — fleshes out the `serve` recipe → `docker compose up --build`.
- **README** — new *Self-hosting (optional)* section.

## Usage
```bash
just serve                     # → http://localhost:8080
docker compose up -d --build   # detached
docker compose down
```

## Verification
Built the image locally and ran it; confirmed 200s for `/`, clean URLs (`/files/`, `/files/projects/2004-of-dinger/`), `/emulator/`, the 6.1 MB `buildroot-bzimage.bin`, `fs.json`, and `rss.xml`, plus a correct 404 for unknown paths. `just fmt-check` and `just lint` pass.

Closes #38.