### PR TITLE
feat: configure david.jensenius.com custom domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: just install
       - name: Build
         env:
-          SITE_URL: https://jensenius.com
+          SITE_URL: https://david.jensenius.com
           BASE_PATH: /
         run: just build
       - name: Audit static site

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM node:26-slim AS build
 
 # SITE_URL/BASE_PATH feed Astro's `site`/`base`. Defaults suit a root-served
 # self-host; the GitHub Pages deploy passes its own values.
-ARG SITE_URL=https://jensenius.com
+ARG SITE_URL=https://david.jensenius.com
 ARG BASE_PATH=/
 ARG V86_IMAGE_REPO=djensenius/website
 ARG V86_IMAGE_TAG=emulator-image

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ release automatically (no auth needed), so the terminal boots in the served site
 
 Configuration (all optional, via env or compose args):
 
-- `SITE_URL` — Astro `site` (default `https://jensenius.com`); sets canonical/sitemap URLs.
+- `SITE_URL` — Astro `site` (default `https://david.jensenius.com`); sets canonical/sitemap URLs.
 - `BASE_PATH` — Astro `base` (default `/`). **Keep this `/` for the bundled Caddy
   config, which serves the site at the container root.** A non-root value (e.g.
   `/website/`) only works if you put a reverse proxy in front that strips the prefix —

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,7 +10,7 @@ const base = `/${rawBase.replace(/^\/+|\/+$/g, '')}/`.replace(/\/{2,}/g, '/');
 
 // https://astro.build/config
 export default defineConfig({
-  site: process.env.SITE_URL || 'https://jensenius.com',
+  site: process.env.SITE_URL || 'https://david.jensenius.com',
   // BASE_PATH lets the GitHub Pages preview deploy (issue #40) serve from the
   // project subpath (e.g. /website) while production at the custom domain uses '/'.
   base,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # All optional; defaults suit a root-served self-host. Set them in a .env
       # file next to this compose file or in the environment before `up`.
       args:
-        SITE_URL: ${SITE_URL:-https://jensenius.com}
+        SITE_URL: ${SITE_URL:-https://david.jensenius.com}
         BASE_PATH: ${BASE_PATH:-/}
         # Point at a fork's emulator-image release, or pin an immutable tag.
         V86_IMAGE_REPO: ${V86_IMAGE_REPO:-djensenius/website}

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+david.jensenius.com


### PR DESCRIPTION
Closes #31.

## What
- Add `public/CNAME` (`david.jensenius.com`) so the GitHub Pages Actions deploy persists the custom domain and serves from root `/`.
- Switch default `SITE_URL` to `https://david.jensenius.com` in Astro config, Dockerfile, `ci.yml`, `docker-compose.yml`, and README, so canonical/sitemap URLs are correct. (Email `david@jensenius.com` addresses left unchanged.)

## Manual steps (DNS — owner)
- **Cloudflare:** `david` CNAME → `djensenius.github.io`, **DNS-only** (grey cloud) so GitHub Pages provisions its Let's Encrypt cert.
- Set the repo Pages custom domain to `david.jensenius.com` and enable **Enforce HTTPS** once the cert is issued.
- Redirects for `jensenius.com` / `davidjensenius.com` (+ `www`) → `david.jensenius.com` via Cloudflare Redirect Rules (proxied). DNS can't redirect on its own.

Verified: build ships `dist/CNAME`; canonical + sitemap use the new domain.