### PR TITLE
ci: verify v86 emulator filesystem is up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,25 @@ jobs:
       - name: Build
         run: just build
 
+  emulator-fs:
+    name: Emulator filesystem
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up tools (mise → Node, just)
+        uses: jdx/mise-action@v4
+      - name: Install dependencies
+        run: just install
+      - name: Regenerate v86 filesystem from Markdown
+        run: just v86-fs
+      - name: Verify committed filesystem is up to date
+        run: |
+          if ! git diff --exit-code -- public/emulator/v86; then
+            echo "::error::The v86 emulator filesystem is out of date. Run 'just v86-fs' and commit the result."
+            exit 1
+          fi
+
   lighthouse:
     name: Lighthouse
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why
When a Markdown content file under `src/content/` changes, the in-browser v86 emulator's 9p filesystem (`public/emulator/v86/fs.json` + `fs/*.bin`) must be regenerated with `just v86-fs` so the terminal shows the same content as the site. Nothing in CI currently verifies this, so a content PR that forgets the regen step would merge with a **stale emulator** (e.g. PR #89 needed those generated files alongside the CV edit).

## What
Adds an **Emulator filesystem** CI job that:
1. runs `just v86-fs` (pure Node, no Docker), then
2. fails via `git diff --exit-code -- public/emulator/v86` if the committed filesystem differs from a fresh regen, with an actionable error message.

## Verified locally
- Clean `main`: regen produces **no diff** → job passes.
- Simulated a content edit without regen → `git diff` detects the drift → job fails as intended.
- Workflow YAML validated.